### PR TITLE
Add temp HuBoard badges using GitHub issue counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 GitHub Pages site for techcorridor.io
 
 [![Build Status](https://travis-ci.org/techcorridorio/techcorridorio.github.io.svg?branch=master)](https://travis-ci.org/techcorridorio/techcorridorio.github.io)
-[![Stories in Ready](https://badge.waffle.io/techcorridorio/techcorridorio.github.io.png?label=ready&title=Ready)](https://waffle.io/techcorridorio/techcorridorio.github.io)
+[![Issues in HuBoard](https://img.shields.io/github/issues/techcorridorio/techcorridorio.github.io.svg?label=HuBoard)](https://huboard.com/techcorridorio/techcorridorio.github.io)
+
+[![HuBoard: Ready](https://img.shields.io/github/issues-raw/techcorridorio/techcorridorio.github.io/1%20-%20Ready.svg?label=Ready)](https://huboard.com/techcorridorio/techcorridorio.github.io)
+[![HuBoard: Working](https://img.shields.io/github/issues-raw/techcorridorio/techcorridorio.github.io/2%20-%20Working.svg?label=Working)](https://huboard.com/techcorridorio/techcorridorio.github.io)
+[![HuBoard: Review](https://img.shields.io/github/issues-raw/techcorridorio/techcorridorio.github.io/3%20-%20Review.svg?label=Review)](https://huboard.com/techcorridorio/techcorridorio.github.io)
 
 ## Goals
 


### PR DESCRIPTION
Closes #21 with imitation HuBoard badges until we get around to resolving https://github.com/huboard/huboard/issues/271.

<img width="185" alt="firefox_2016-04-21_20-56-44" src="https://cloud.githubusercontent.com/assets/133987/14729457/ad58fe4e-0803-11e6-8d99-407f4d6b62a2.png">

<!---
@huboard:{"order":21.0,"milestone_order":23,"custom_state":""}
-->
